### PR TITLE
fix(frontend): XSRF on cloud upload and share token cookie on HTTP

### DIFF
--- a/aird/templates/share.html
+++ b/aird/templates/share.html
@@ -1772,6 +1772,11 @@
       uploading: false
     };
 
+    function getXSRFToken() {
+      const match = document.cookie.match(/_xsrf=([^;]*)/);
+      return match ? decodeURIComponent(match[1]) : '';
+    }
+
     function getFileIcon(filename) {
       const ext = filename.toLowerCase().split('.').pop();
       const lowerFilename = filename.toLowerCase();
@@ -2262,8 +2267,14 @@
       uploadInput.disabled = true;
 
       try {
+        const xsrfHeaders = {};
+        const xsrf = getXSRFToken();
+        if (xsrf) {
+          xsrfHeaders['X-XSRFToken'] = xsrf;
+        }
         const response = await fetch(`/api/cloud/${cloudState.currentProvider.name}/upload`, {
           method: 'POST',
+          headers: xsrfHeaders,
           body: formData
         });
         const payload = await response.json().catch(() => ({}));
@@ -2557,12 +2568,6 @@
         if (isSelected) row.classList.add('selected');
         elements.fileTableBody.appendChild(row);
       });
-    }
-
-    // CSRF Protection: Get XSRF token from cookie
-    function getXSRFToken() {
-      const match = document.cookie.match(/_xsrf=([^;]*)/);
-      return match ? decodeURIComponent(match[1]) : '';
     }
 
     // Share management functions

--- a/aird/templates/shared_list.html
+++ b/aird/templates/shared_list.html
@@ -250,7 +250,8 @@
             currentAuthToken = token;
             sessionStorage.setItem(`share_token_${shareId}`, token);
             // Also set a cookie for server-side access
-            document.cookie = `share_token_${shareId}=${token}; path=/; max-age=3600; SameSite=Lax`;
+            const secureAttr = globalThis.location.protocol === 'https:' ? '; Secure' : '';
+            document.cookie = `share_token_${shareId}=${token}; path=/; max-age=3600; SameSite=Lax${secureAttr}`;
         }
 
         // Enhanced fetch function that automatically includes auth token

--- a/aird/templates/token_verification.html
+++ b/aird/templates/token_verification.html
@@ -243,7 +243,8 @@
       currentAuthToken = token;
       sessionStorage.setItem(`share_token_${shareId}`, token);
       // Also set a cookie for server-side access
-      document.cookie = `share_token_${shareId}=${token}; path=/; max-age=3600; SameSite=Lax; Secure`;
+      const secureAttr = globalThis.location.protocol === 'https:' ? '; Secure' : '';
+      document.cookie = `share_token_${shareId}=${token}; path=/; max-age=3600; SameSite=Lax${secureAttr}`;
     }
 
     // Enhanced fetch function that automatically includes auth token


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Cloud upload on the share page** posted `FormData` without `X-XSRFToken`. With Tornado `xsrf_cookies: True`, that yields 403 and surfaces as a failed upload / error payload. The upload `fetch` now includes the header when `_xsrf` is present.
- **`getXSRFToken` in `share.html`** is defined once at the top of the main script so cloud code and share-management code share the same helper (removed the later duplicate).
- **Share access cookies**: `token_verification.html` always used `Secure`, which prevents the browser from storing the cookie on plain HTTP; `shared_list.html` did not. Both now set `Secure` only when `location.protocol === 'https:'`, so HTTPS stays strict and HTTP dev/local use still gets a cookie for server-side file access.

## Testing

- Not run in this environment (full test deps e.g. `ldap3` not installed). Changes are limited to inline template scripts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96dd0d9a-8b7a-49b3-ba2c-5b3583b7db1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96dd0d9a-8b7a-49b3-ba2c-5b3583b7db1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

