### PR TITLE
Raise test coverage above 80% on ft branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ node_modules/
 *.log
 *.pdf
 *.iso
+*aird.db
+*.exe
+*.jar
+*.ps1
 28092_heic.webp
 *mcp-server*
 *.md

--- a/.gitignore
+++ b/.gitignore
@@ -42,11 +42,8 @@ node_modules/
 *.log
 *.pdf
 *.iso
-*aird.db
-*.exe
-*.jar
-*.ps1
 28092_heic.webp
 *mcp-server*
 *.md
 *.err
+coverage.json

--- a/tests/test_abac_handlers.py
+++ b/tests/test_abac_handlers.py
@@ -1,0 +1,319 @@
+"""Tests for ABAC admin handlers and helpers."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aird.db import init_db
+from aird.handlers.abac_handlers import (
+    AdminPolicyAPIHandler,
+    AdminTagAPIHandler,
+    AdminUserAttributeAPIHandler,
+    PolicyDecisionsAPIHandler,
+    _bool_arg,
+    _parse_actions,
+    _parse_condition,
+    _parse_target_actions,
+    _validate_policy_payload,
+)
+from tests.handler_helpers import _default_services, authenticate, patch_db_conn, prepare_handler
+
+
+@pytest.fixture
+def db_conn():
+    import sqlite3
+
+    conn = sqlite3.connect(":memory:")
+    init_db(conn)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def admin_app():
+    app = MagicMock()
+    app.settings = {
+        "cookie_secret": "test",
+        "services": _default_services(),
+    }
+    return app
+
+
+@pytest.fixture
+def admin_request():
+    req = MagicMock()
+    req.body = b"{}"
+    req.remote_ip = "127.0.0.1"
+    req.connection = MagicMock()
+    req.connection.context = MagicMock()
+    req.protocol = "http"
+    return req
+
+
+class TestAbacHelpers:
+    def test_bool_arg(self):
+        assert _bool_arg(None) is False
+        assert _bool_arg("true") is True
+        assert _bool_arg("0") is False
+
+    def test_parse_actions(self):
+        assert _parse_actions("") == []
+        assert _parse_actions("read, write") == ["read", "write"]
+        assert _parse_actions('["read","write"]') == ["read", "write"]
+        assert _parse_actions("[bad") == ["[bad"]
+
+    def test_parse_target_actions(self):
+        assert _parse_target_actions("a,b") == ["a", "b"]
+        assert _parse_target_actions(["x"]) == ["x"]
+        assert _parse_target_actions(42) == []
+
+    def test_parse_condition(self):
+        assert _parse_condition(None) == ({}, None)
+        assert _parse_condition('{"role":"admin"}') == ({"role": "admin"}, None)
+        cond, err = _parse_condition("{bad")
+        assert cond == {}
+        assert err is not None
+        cond, err = _parse_condition([])
+        assert err == "condition must be a JSON object"
+
+    def test_validate_policy_payload(self):
+        data, err = _validate_policy_payload({})
+        assert err == "name is required"
+        data, err = _validate_policy_payload(
+            {
+                "name": "p1",
+                "effect": "permit",
+                "target_actions": ["read"],
+                "condition": {},
+                "enabled": "on",
+            }
+        )
+        assert err is None
+        assert data["enabled"] is True
+
+
+class TestAdminTagAPIHandler:
+    def test_tag_crud(self, admin_app, admin_request, db_conn):
+        handler = AdminTagAPIHandler(admin_app, admin_request)
+        authenticate(handler)
+        with patch_db_conn(db_conn):
+            handler.get()
+            assert "tags" in handler.write.call_args[0][0]
+
+            admin_request.body = json.dumps(
+                {"tag": "conf", "glob_pattern": "*.secret", "priority": 1}
+            ).encode()
+            handler.post()
+            handler.set_status.assert_called_with(201)
+            tag_id = handler.write.call_args[0][0]["id"]
+
+            admin_request.body = json.dumps(
+                {"id": tag_id, "glob_pattern": "*.classified"}
+            ).encode()
+            handler.put()
+            assert handler.write.call_args[0][0]["updated"] is True
+
+            admin_request.body = json.dumps({"id": tag_id}).encode()
+            handler.delete()
+            assert handler.write.call_args[0][0]["deleted"] is True
+
+    def test_tag_post_validation(self, admin_app, admin_request, db_conn):
+        handler = AdminTagAPIHandler(admin_app, admin_request)
+        authenticate(handler)
+        with patch_db_conn(db_conn):
+            admin_request.body = json.dumps({"tag": "", "glob_pattern": ""}).encode()
+            handler.post()
+            handler.set_status.assert_called_with(400)
+
+            admin_request.body = json.dumps({"ids": []}).encode()
+            handler.delete()
+            handler.set_status.assert_called_with(400)
+
+
+class TestAdminPolicyAPIHandler:
+    def test_policy_crud(self, admin_app, admin_request, db_conn):
+        handler = AdminPolicyAPIHandler(admin_app, admin_request)
+        authenticate(handler)
+        with patch_db_conn(db_conn):
+            handler.get()
+            assert "policies" in handler.write.call_args[0][0]
+
+            admin_request.body = json.dumps(
+                {
+                    "name": "allow-read",
+                    "effect": "permit",
+                    "target_actions": ["read"],
+                    "condition": {"role": "user"},
+                }
+            ).encode()
+            handler.post()
+            handler.set_status.assert_called_with(201)
+            pid = handler.write.call_args[0][0]["id"]
+
+            handler.get(str(pid))
+            assert handler.write.call_args[0][0]["name"] == "allow-read"
+
+            admin_request.body = json.dumps(
+                {
+                    "name": "allow-read",
+                    "effect": "permit",
+                    "target_actions": ["read", "write"],
+                    "condition": {},
+                }
+            ).encode()
+            handler.post(str(pid))
+            assert handler.write.call_args[0][0]["updated"] is True
+
+            admin_request.body = b"{}"
+            handler.delete(str(pid))
+            assert handler.write.call_args[0][0]["deleted"] is True
+
+
+class TestAdminUserAttributeAPIHandler:
+    def test_user_attribute_api(self, admin_app, admin_request, db_conn):
+        handler = AdminUserAttributeAPIHandler(admin_app, admin_request)
+        authenticate(handler)
+        with patch_db_conn(db_conn):
+            admin_request.body = json.dumps(
+                {"username": "alice", "key": "dept", "value": "eng"}
+            ).encode()
+            handler.post()
+            assert handler.write.call_args[0][0]["ok"] is True
+
+            handler.get()
+            assert len(handler.write.call_args[0][0]["attrs"]) == 1
+
+            admin_request.body = json.dumps(
+                {"username": "alice", "key": "dept"}
+            ).encode()
+            handler.delete()
+            assert handler.write.call_args[0][0]["deleted"] is True
+
+
+class TestPolicyDecisionsAPIHandler:
+    def test_list_decisions(self, admin_app, admin_request, db_conn):
+        from aird.db.policy_decisions import log_policy_decision
+
+        log_policy_decision(
+            db_conn, username="alice", action="read", decision="permit"
+        )
+        handler = PolicyDecisionsAPIHandler(admin_app, admin_request)
+        authenticate(handler)
+        handler.get_argument = MagicMock(side_effect=lambda k, default="": {"limit": "10", "offset": "0"}.get(k, default))
+        with patch_db_conn(db_conn):
+            handler.get()
+            payload = handler.write.call_args[0][0]
+            assert len(payload["decisions"]) == 1
+
+
+class TestAdminTagsPageHandler:
+    def test_render_tags_page(self, admin_app, admin_request, db_conn):
+        from aird.handlers.abac_handlers import AdminTagsHandler
+
+        handler = AdminTagsHandler(admin_app, admin_request)
+        authenticate(handler)
+        with patch_db_conn(db_conn), patch.object(handler, "render") as render:
+            handler.get()
+            render.assert_called_once()
+            assert render.call_args[0][0] == "admin_tags.html"
+
+
+class TestAbacPolicyValidation:
+    def test_policy_post_validation_error(self, admin_app, admin_request, db_conn):
+        handler = AdminPolicyAPIHandler(admin_app, admin_request)
+        authenticate(handler)
+        with patch_db_conn(db_conn):
+            admin_request.body = json.dumps({"name": ""}).encode()
+            handler.post()
+            handler.set_status.assert_called_with(400)
+
+    def test_policy_get_not_found(self, admin_app, admin_request, db_conn):
+        handler = AdminPolicyAPIHandler(admin_app, admin_request)
+        authenticate(handler)
+        with patch_db_conn(db_conn):
+            handler.get("99999")
+            handler.set_status.assert_called_with(404)
+
+
+class TestAbacTagDeletePaths:
+    def test_delete_by_name_and_bulk(self, admin_app, admin_request, db_conn):
+        from aird.db.resource_tags import insert_resource_tag
+
+        tid = insert_resource_tag(db_conn, "t1", "*.a")
+        handler = AdminTagAPIHandler(admin_app, admin_request)
+        authenticate(handler)
+        with patch_db_conn(db_conn):
+            admin_request.body = json.dumps({"tag": "t1"}).encode()
+            handler.delete()
+            assert handler.write.call_args[0][0]["count"] == 1
+
+            tid2 = insert_resource_tag(db_conn, "t2", "*.b")
+            admin_request.body = json.dumps({"ids": [tid2]}).encode()
+            handler.delete()
+            assert tid2 in handler.write.call_args[0][0]["ids"]
+
+            admin_request.body = json.dumps({"id": 99999}).encode()
+            handler.delete()
+            handler.set_status.assert_called_with(404)
+
+
+class TestPolicyDecisionsWebSocket:
+    def test_open_non_admin_closed(self):
+        from aird.handlers.abac_handlers import PolicyDecisionsWebSocket
+
+        app = MagicMock()
+        app.settings = {"services": _default_services()}
+        handler = PolicyDecisionsWebSocket(app, MagicMock())
+        handler.get_current_user = MagicMock(return_value={"username": "user", "role": "user"})
+        handler.register_connection = MagicMock(return_value=True)
+        handler.close = MagicMock()
+        handler.open()
+        handler.close.assert_called_once()
+
+    def test_on_decision_broadcast(self):
+        from aird.core.events import PolicyDecisionEvent, now_ts
+        from aird.handlers.abac_handlers import PolicyDecisionsWebSocket
+
+        handler = PolicyDecisionsWebSocket(MagicMock(), MagicMock())
+        handler.write_message = MagicMock()
+        event = PolicyDecisionEvent(
+            "alice", "read", "/a", "permit", "ok", 1, "policy", "127.0.0.1", now_ts()
+        )
+        handler._on_decision(event)
+        handler.write_message.assert_called_once()
+
+
+class TestAdminHtmlHandlers:
+    def test_admin_policies_page(self, admin_app, admin_request, db_conn):
+        from aird.handlers.abac_handlers import AdminPoliciesHandler, AdminUserAttributesHandler
+
+        handler = AdminPoliciesHandler(admin_app, admin_request)
+        authenticate(handler)
+        with patch_db_conn(db_conn), patch.object(handler, "render") as render:
+            handler.get()
+            render.assert_called_once_with(
+                "admin_policies.html",
+                policies=[],
+                error="",
+            )
+
+        attrs_handler = AdminUserAttributesHandler(admin_app, admin_request)
+        authenticate(attrs_handler)
+        with patch_db_conn(db_conn), patch.object(attrs_handler, "render") as render:
+            attrs_handler.get()
+            render.assert_called_once()
+
+
+class TestAbacTagPutErrors:
+    def test_put_not_found(self, admin_app, admin_request, db_conn):
+        handler = AdminTagAPIHandler(admin_app, admin_request)
+        authenticate(handler)
+        with patch_db_conn(db_conn):
+            admin_request.body = json.dumps(
+                {"id": 99999, "glob_pattern": "*.x"}
+            ).encode()
+            handler.put()
+            handler.set_status.assert_called_with(404)

--- a/tests/test_abac_handlers.py
+++ b/tests/test_abac_handlers.py
@@ -294,11 +294,9 @@ class TestAdminHtmlHandlers:
         authenticate(handler)
         with patch_db_conn(db_conn), patch.object(handler, "render") as render:
             handler.get()
-            render.assert_called_once_with(
-                "admin_policies.html",
-                policies=[],
-                error="",
-            )
+            render.assert_called_once()
+            assert render.call_args[0][0] == "admin_policies.html"
+            assert isinstance(render.call_args[1]["policies"], list)
 
         attrs_handler = AdminUserAttributesHandler(admin_app, admin_request)
         authenticate(attrs_handler)

--- a/tests/test_cli_session_extended.py
+++ b/tests/test_cli_session_extended.py
@@ -182,6 +182,8 @@ def test_download_file(tmp_path, monkeypatch):
     response.iter_content.return_value = [b"abc"]
     response.__enter__ = MagicMock(return_value=response)
     response.__exit__ = MagicMock(return_value=False)
+    head = MagicMock(status_code=200, headers={"Content-Length": "3"})
+    client.http.head.return_value = head
     client.http.get.return_value = response
     dest = tmp_path / "out" / "file.bin"
     with patch.object(client, "ensure_auth"):

--- a/tests/test_cli_session_extended.py
+++ b/tests/test_cli_session_extended.py
@@ -1,0 +1,301 @@
+"""Extended CLI session/client tests for coverage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from aird.cli.session import (
+    AirdAPIError,
+    AirdAuthError,
+    AirdClient,
+    _collect_local_upload_files,
+    _cookie_to_dict,
+    _load_cookies,
+    _run_path_jobs,
+    _save_cookies,
+)
+
+
+def test_api_errors():
+    err = AirdAPIError("fail", 403)
+    assert err.status == 403
+    assert "fail" in str(err)
+
+
+def test_cookie_to_dict():
+    cookie = requests.cookies.create_cookie("sid", "val", domain="x.com", path="/")
+    data = _cookie_to_dict(cookie)
+    assert data["name"] == "sid"
+    assert data["value"] == "val"
+
+
+def test_save_and_load_cookies(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", str(tmp_path))
+    session = requests.Session()
+    session.cookies.set("sid", "abc")
+    session.headers["Authorization"] = "Bearer tok"
+    _save_cookies(session)
+
+    fresh = requests.Session()
+    assert _load_cookies(fresh) is True
+    assert fresh.cookies.get("sid") == "abc"
+    assert fresh.headers["Authorization"] == "Bearer tok"
+
+
+def test_load_cookies_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", str(tmp_path))
+    assert _load_cookies(requests.Session()) is False
+
+
+def test_collect_local_upload_files(tmp_path):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "b.txt").write_text("b", encoding="utf-8")
+    files = _collect_local_upload_files(tmp_path, "remote")
+    rels = sorted(remote for _, remote in files)
+    assert rels == ["remote", "remote/sub"]
+
+
+def test_run_path_jobs():
+    seen = []
+
+    def job(path: str) -> str:
+        seen.append(path)
+        return path
+
+    count = _run_path_jobs(["a", "b"], job, 2, on_progress=lambda p: seen.append(f"done:{p}"))
+    assert count == 2
+    assert "done:a" in seen
+
+
+def test_client_requires_server(monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    monkeypatch.delenv("AIRD_SERVER_URL", raising=False)
+    with patch("aird.cli.session.get_server_url", return_value=None):
+        with pytest.raises(AirdAuthError, match="Server URL not set"):
+            AirdClient()
+
+
+def test_client_set_bearer_and_clear(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", str(tmp_path))
+    client = AirdClient("https://example.com")
+    client.set_bearer_token("abc")
+    assert client.http.headers["Authorization"] == "Bearer abc"
+    client.set_bearer_token("")
+    assert "Authorization" not in client.http.headers
+    client.http.cookies.set("sid", "x")
+    client.clear_session()
+    assert not client.http.cookies
+    assert client._xsrf is None
+
+
+def test_check_auth_and_list_dir(monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    client.http = MagicMock()
+
+    ok = MagicMock(status_code=200)
+    ok.json.return_value = {"files": [{"name": "a.txt", "is_dir": False, "size": 1}]}
+    client.http.get.return_value = ok
+    assert client.check_auth() == ok.json.return_value
+
+    client.http.get.return_value = MagicMock(status_code=401)
+    with pytest.raises(AirdAuthError):
+        client.check_auth()
+
+    client.http.get.return_value = MagicMock(status_code=500)
+    with pytest.raises(AirdAPIError):
+        client.check_auth()
+
+    with patch.object(client, "ensure_auth"):
+        client.http.get.return_value = ok
+        files = client.list_dir()
+        assert len(files) == 1
+
+        client.http.get.return_value = MagicMock(status_code=403)
+        with pytest.raises(AirdAPIError):
+            client.list_dir("secret")
+
+
+def test_iter_tree(monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    with patch.object(
+        client,
+        "list_dir",
+        side_effect=[
+            [
+                {"name": "sub", "is_dir": True},
+                {"name": "root.txt", "is_dir": False, "size_bytes": 3},
+            ],
+            [{"name": "nested.txt", "is_dir": False, "size": 5}],
+        ],
+    ):
+        items = list(client.iter_tree())
+    assert ("root.txt", 3) in items
+    assert ("sub/nested.txt", 5) in items
+
+
+def test_login_password(monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    client.http = MagicMock()
+    with patch.object(client, "refresh_xsrf", return_value="xsrf"), patch.object(
+        client, "save"
+    ):
+        client.http.post.return_value = MagicMock(status_code=302)
+        client.login_password("alice", "secret")
+        client.http.post.assert_called_once()
+
+        client.http.post.return_value = MagicMock(status_code=401)
+        with pytest.raises(AirdAuthError):
+            client.login_password("alice", "bad")
+
+
+def test_upload_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    client.http = MagicMock()
+    local = tmp_path / "up.txt"
+    local.write_text("data", encoding="utf-8")
+    with patch.object(client, "ensure_auth"), patch.object(
+        client, "_xsrf_header", return_value={}
+    ):
+        client.http.post.return_value = MagicMock(status_code=200)
+        client.upload_file(local, "docs")
+        client.http.post.assert_called_once()
+        with pytest.raises(FileNotFoundError):
+            client.upload_file(tmp_path / "missing.txt")
+
+
+def test_download_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    client.http = MagicMock()
+    response = MagicMock(status_code=200)
+    response.iter_content.return_value = [b"abc"]
+    response.__enter__ = MagicMock(return_value=response)
+    response.__exit__ = MagicMock(return_value=False)
+    client.http.get.return_value = response
+    dest = tmp_path / "out" / "file.bin"
+    with patch.object(client, "ensure_auth"):
+        client.download_file("remote/file.bin", dest)
+    assert dest.read_bytes() == b"abc"
+
+
+def test_ensure_auth_expired(monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    with patch.object(client, "check_auth", side_effect=AirdAuthError("no")):
+        with pytest.raises(AirdAuthError, match="Session expired"):
+            client.ensure_auth()
+
+
+def test_upload_tree(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    (tmp_path / "f.txt").write_text("x", encoding="utf-8")
+    with patch.object(client, "clone") as clone_mock:
+        clone = MagicMock()
+        clone_mock.return_value = clone
+        count = client.upload_tree(tmp_path, "remote")
+    assert count == 1
+    clone.upload_file.assert_called_once()
+    with pytest.raises(NotADirectoryError):
+        client.upload_tree(tmp_path / "f.txt")
+
+
+def test_download_tree(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    with patch.object(client, "iter_tree", return_value=[("a.txt", 1)]), patch.object(
+        client, "clone", return_value=client
+    ), patch.object(client, "download_file") as dl:
+        assert client.download_tree("", tmp_path) == 1
+        dl.assert_called_once()
+
+
+def test_share_helpers(monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    client.http = MagicMock()
+    with patch.object(client, "ensure_auth"):
+        client.http.get.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"shares": {"s1": {"id": "s1"}}})
+        )
+        share, mine = client.find_share("s1")
+        assert mine is True
+        assert share["id"] == "s1"
+
+        client.http.get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"shares": {}, "shared_with_me": [{"id": "s2"}]}),
+        )
+        share, mine = client.find_share("s2")
+        assert mine is False
+
+        client.http.get.return_value = MagicMock(
+            status_code=200,
+            text='<script id="files-json">["a.txt"]</script>',
+        )
+        assert client.share_file_paths("s1") == ["a.txt"]
+
+
+def test_expand_paths_to_files(monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    with patch.object(client, "list_dir"), patch.object(
+        client, "iter_tree", return_value=[("docs/a.txt", 1)]
+    ):
+        assert client.expand_paths_to_files(["docs"]) == ["docs/a.txt"]
+
+    with patch.object(client, "list_dir", side_effect=AirdAPIError("missing", 404)):
+        assert client.expand_paths_to_files(["solo.txt"]) == ["solo.txt"]
+
+
+def test_verify_share(monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    client.http = MagicMock()
+    with patch.object(client, "refresh_xsrf"), patch.object(client, "_xsrf_header", return_value={}), patch.object(
+        client, "save"
+    ):
+        client.http.post.return_value = MagicMock(status_code=200)
+        client.verify_share("sid", "tok")
+        client.http.post.return_value = MagicMock(status_code=403)
+        with pytest.raises(AirdAPIError):
+            client.verify_share("sid", "bad")
+
+
+def test_download_share_flows(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIRD_CLI_CONFIG_DIR", "/tmp/unused-aird-cli")
+    client = AirdClient("https://example.com")
+    with patch.object(
+        client, "find_share", return_value=({"paths": ["a.txt"]}, True)
+    ), patch.object(client, "expand_paths_to_files", return_value=["a.txt"]), patch.object(
+        client, "clone"
+    ) as clone_mock:
+        clone = MagicMock()
+        clone_mock.return_value = clone
+        count = client.download_share("s1", tmp_path)
+    assert count == 1
+    clone.download_file.assert_called_once()
+
+    with patch.object(
+        client, "find_share", return_value=(None, False)
+    ), patch.object(client, "verify_share"), patch.object(
+        client, "share_file_paths", return_value=["b.txt"]
+    ), patch.object(client, "clone", return_value=clone):
+        count = client.download_share("s2", tmp_path, share_token="tok")
+    assert count == 1
+
+    with patch.object(client, "list_shares", return_value={"shares": {"s1": {}}, "shared_with_me": []}), patch.object(
+        client, "download_share", return_value=2
+    ):
+        assert client.download_all_shares(tmp_path) == 2

--- a/tests/test_cli_transfer_http.py
+++ b/tests/test_cli_transfer_http.py
@@ -1,0 +1,98 @@
+"""Tests for aird/cli/transfer_http.py parallel range transfers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from aird.cli.transfer_http import (
+    _clone_session,
+    _put_chunk,
+    _range_session,
+    download_file_ranged,
+    upload_file_ranged,
+)
+
+
+def test_clone_session():
+    src = requests.Session()
+    src.cookies.set("sid", "abc")
+    src.headers["Authorization"] = "Bearer tok"
+    clone = _clone_session(src)
+    assert clone.cookies.get("sid") == "abc"
+    assert clone.headers["Authorization"] == "Bearer tok"
+    assert clone is not src
+
+
+def test_range_session_success():
+    http = MagicMock()
+    http.post.return_value = MagicMock(status_code=201, json=lambda: {"upload_id": "up-1"})
+    uid = _range_session(http, "https://x.test", {}, "docs", "big.bin", 1000)
+    assert uid == "up-1"
+
+
+def test_range_session_failure():
+    http = MagicMock()
+    http.post.return_value = MagicMock(status_code=500, text="fail")
+    with pytest.raises(RuntimeError, match="Range session failed"):
+        _range_session(http, "https://x.test", {}, "", "f", 1)
+
+
+def test_put_chunk_complete():
+    http = MagicMock()
+    http.put.return_value = MagicMock(status_code=201)
+    assert _put_chunk(http, "https://x.test", {}, "up-1", b"x", 0, 0, 1) is True
+
+
+def test_put_chunk_error():
+    http = MagicMock()
+    http.put.return_value = MagicMock(status_code=500, text="bad")
+    with pytest.raises(RuntimeError, match="Chunk upload failed"):
+        _put_chunk(http, "https://x.test", {}, "up-1", b"x", 0, 0, 1)
+
+
+def test_upload_file_ranged(tmp_path):
+    local = tmp_path / "data.bin"
+    local.write_bytes(b"a" * 32)
+    http = MagicMock()
+    http.post.return_value = MagicMock(status_code=201, json=lambda: {"upload_id": "up-1"})
+    http.put.return_value = MagicMock(status_code=201)
+
+    with patch("aird.cli.transfer_http._clone_session", side_effect=lambda s: s):
+        upload_file_ranged(
+            http,
+            "https://x.test",
+            {"X-XSRFToken": "xsrf"},
+            local,
+            chunk_size=16,
+            workers=1,
+        )
+    assert http.put.called
+
+
+def test_download_file_ranged(tmp_path):
+    http = MagicMock()
+    http.head.return_value = MagicMock(status_code=200, headers={"Content-Length": "32"})
+    http.get.return_value = MagicMock(status_code=206, content=b"a" * 32)
+    dest = tmp_path / "out.bin"
+
+    with patch("aird.cli.transfer_http._clone_session", side_effect=lambda s: s):
+        download_file_ranged(
+            http,
+            "https://x.test",
+            "docs/file.bin",
+            dest,
+            chunk_size=32,
+            workers=1,
+        )
+    assert dest.read_bytes() == b"a" * 32
+
+
+def test_download_file_ranged_head_failure():
+    http = MagicMock()
+    http.head.return_value = MagicMock(status_code=404)
+    with pytest.raises(RuntimeError, match="HEAD failed"):
+        download_file_ranged(http, "https://x.test", "missing", Path("/tmp/x"))

--- a/tests/test_database_ldap.py
+++ b/tests/test_database_ldap.py
@@ -15,7 +15,9 @@ from aird.database.ldap import (
     get_ldap_sync_logs,
     extract_username_from_dn,
     sync_ldap_users,
+    _collect_usernames_from_ldap_entries,
 )
+from aird.db.users import get_user_by_username
 
 
 @pytest.fixture
@@ -422,3 +424,40 @@ class TestSyncLdapUsers:
         assert result["status"] == "success"
         assert len(result["config_results"]) == 1
         assert result["config_results"][0]["status"] == "error"
+
+    @patch("aird.database.ldap.Server")
+    @patch("aird.database.ldap.Connection")
+    def test_sync_ldap_success(self, mock_conn_class, mock_server_class, db_conn):
+        from aird.db import init_db
+
+        init_db(db_conn)
+        create_ldap_config(
+            db_conn, "Corp", "ldap://corp", "dc=corp", "member", "uid={username},dc=corp"
+        )
+        entry = MagicMock()
+        entry.member = ["uid=alice,dc=corp"]
+        mock_conn = MagicMock()
+        mock_conn.bind.return_value = True
+        mock_conn.entries = [entry]
+        mock_conn_class.return_value = mock_conn
+
+        result = sync_ldap_users(db_conn)
+        assert result["status"] == "success"
+        assert result["users_created"] >= 1
+        assert get_user_by_username(db_conn, "alice") is not None
+
+
+class TestCollectLdapUsernames:
+    def test_collect_usernames_from_entries(self):
+        entry = MagicMock()
+        entry.member = ["uid=bob,dc=example,dc=com"]
+        users = _collect_usernames_from_ldap_entries(
+            [entry], "member", "uid={username},dc=example,dc=com"
+        )
+        assert users == {"bob"}
+
+        empty = MagicMock(spec=[])
+        users = _collect_usernames_from_ldap_entries(
+            [empty], "member", "uid={username}"
+        )
+        assert users == set()

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -74,3 +74,20 @@ def test_notify_share_created(mock_send, _mock_flag):
 @patch("aird.config.PORT", 443)
 def test_public_base_url_https_default_port():
     assert public_base_url() == "https://files.example.com"
+
+
+@patch("aird.email.brevo.requests.post")
+def test_brevo_send_errors(mock_post):
+    client = BrevoClient("", sender_email="")
+    assert client.configured is False
+    assert client.send("a@b.co", "s", html_content="<p>x</p>") is False
+    assert client.send("", "s", html_content="<p>x</p>") is False
+
+    client = BrevoClient("key", sender_email="noreply@aird.test")
+    mock_post.side_effect = __import__("requests").RequestException("net")
+    assert client.send("a@b.co", "s", html_content="<p>x</p>") is False
+
+    mock_post.side_effect = None
+    mock_post.return_value = MagicMock(status_code=500, text="err")
+    assert client.send("a@b.co", "s", html_content="<p>x</p>") is False
+

--- a/tests/test_file_send.py
+++ b/tests/test_file_send.py
@@ -1,0 +1,46 @@
+"""Tests for zero-copy file send helpers."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aird.core.file_send import sendfile_available, sendfile_to_socket, _sendfile_sync
+
+
+def test_sendfile_available_on_linux():
+    with patch.object(sys, "platform", "linux"):
+        with patch.object(os, "sendfile", create=True):
+            assert sendfile_available() is True
+    with patch.object(sys, "platform", "darwin"):
+        assert sendfile_available() is False
+
+
+@pytest.mark.asyncio
+async def test_sendfile_unsupported_platform():
+    with patch("aird.core.file_send.sendfile_available", return_value=False):
+        assert await sendfile_to_socket(MagicMock(), "/tmp/x") is False
+
+
+@pytest.mark.asyncio
+async def test_sendfile_success(tmp_path):
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"hello")
+    sock = MagicMock()
+    sock.fileno.return_value = 1
+    with patch("aird.core.file_send.sendfile_available", return_value=True), patch(
+        "aird.core.file_send._sendfile_sync", return_value=5
+    ):
+        assert await sendfile_to_socket(sock, str(src)) is True
+
+
+def test_sendfile_sync_partial():
+    out_fd, in_fd = 1, 2
+    with patch("os.sendfile", side_effect=[3, 0]) as sf:
+        sent = _sendfile_sync(out_fd, in_fd, 0, 10)
+    assert sent == 3
+    assert sf.call_count == 2

--- a/tests/test_folder_size.py
+++ b/tests/test_folder_size.py
@@ -3,6 +3,7 @@
 import os
 
 import pytest
+from unittest.mock import patch
 
 from aird.core.folder_size import FolderSizeWalker, compute_folder_size
 
@@ -43,3 +44,25 @@ def test_compute_folder_size(sample_tree):
     total, count = compute_folder_size(sample_tree)
     assert count == 3
     assert total == 175
+
+
+def test_norm_rel_path_and_resolve(tmp_path):
+    from aird.core.folder_size import norm_rel_path, resolve_folder_abspath
+
+    assert norm_rel_path("\\docs\\") == "docs"
+    root = str(tmp_path)
+    (tmp_path / "docs").mkdir()
+    assert resolve_folder_abspath(root, "docs") is not None
+    assert resolve_folder_abspath(root, "../etc") is None
+    assert resolve_folder_abspath(root, "missing") is None
+
+
+def test_walker_account_os_error(tmp_path):
+    root = tmp_path / "walk"
+    root.mkdir()
+    (root / "f.txt").write_bytes(b"x")
+    walker = FolderSizeWalker(str(root))
+    with patch("os.path.getsize", side_effect=OSError("nope")):
+        walker.step()
+    assert walker.file_count == 1
+

--- a/tests/test_http_range.py
+++ b/tests/test_http_range.py
@@ -39,3 +39,25 @@ def test_ranges_json_roundtrip():
     data = ranges_to_json([ByteRange(0, 5), ByteRange(6, 10)])
     restored = ranges_from_json(data)
     assert restored == merge_ranges([ByteRange(0, 5), ByteRange(6, 10)])
+
+
+def test_parse_range_header_invalid_cases():
+    assert parse_range_header(None, 100) is None
+    assert parse_range_header("bytes=-0", 100) is None
+    assert parse_range_header("bytes=500-100", 100) is None
+    assert parse_range_header("invalid", 100) is None
+    assert ByteRange(0, 9).length == 10
+
+
+def test_parse_content_range_invalid():
+    assert parse_content_range(None) is None
+    assert parse_content_range("bad") is None
+    assert parse_content_range("bytes 5-2/10") is None
+    assert parse_content_range("bytes 0-9/*") == (0, 9, None)
+
+
+def test_ranges_from_json_skips_bad_items():
+    assert ranges_from_json([[0, 1], "bad", [2, 3]]) == merge_ranges(
+        [ByteRange(0, 1), ByteRange(2, 3)]
+    )
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1015,3 +1015,23 @@ class TestAssignAdminEdgeCases:
 
     def test_none_admin_users(self, db_conn):
         assign_admin_privileges(db_conn, None)
+
+
+class TestBuildAppContext:
+    def test_build_app_context_and_application(self):
+        from aird.main import _build_app_context, _build_application
+
+        ctx = _build_app_context()
+        assert ctx.event_bus is not None
+        assert ctx.services.get("policy_service") is not None
+        app = _build_application()
+        assert app is not None
+        assert "app_context" in app.settings
+
+    def test_run_cleanup_logs_deleted(self):
+        with patch("aird.main.constants.DB_CONN", MagicMock()), patch(
+            "aird.main.cleanup_expired_shares", return_value=2
+        ), patch("aird.main.tornado.ioloop.IOLoop.current") as loop:
+            _run_cleanup_expired_shares()
+            loop.return_value.call_later.assert_called_once()
+

--- a/tests/test_mmap_extended.py
+++ b/tests/test_mmap_extended.py
@@ -1,0 +1,86 @@
+"""Additional mmap handler unit tests."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from aird.core.mmap_handler import MMapFileHandler, _SyncChunkReader, _read_chunks_sync
+
+
+def test_read_chunks_sync():
+    with tempfile.NamedTemporaryFile(delete=False) as fh:
+        fh.write(b"0123456789")
+        path = fh.name
+    try:
+        chunks = _read_chunks_sync(path, 2, 5, 10, 3)
+        assert b"".join(chunks) == b"2345"
+    finally:
+        os.unlink(path)
+
+
+def test_sync_chunk_reader_mmap_and_plain():
+    with tempfile.NamedTemporaryFile(delete=False) as fh:
+        fh.write(b"abcdefghij")
+        path = fh.name
+    try:
+        for use_mmap in (False, True):
+            reader = _SyncChunkReader(path, 0, 4, 10, 3, use_mmap=use_mmap)
+            reader.open()
+            parts = []
+            while True:
+                chunk = reader.read_next()
+                if chunk is None:
+                    break
+                parts.append(chunk)
+            reader.close()
+            assert b"".join(parts) == b"abcde"
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.asyncio
+async def test_serve_file_chunk_empty_tail():
+    with tempfile.NamedTemporaryFile(delete=False) as fh:
+        fh.write(b"abc")
+        path = fh.name
+    try:
+        chunks = [c async for c in MMapFileHandler.serve_file_chunk(path, start=1, end=1)]
+        assert b"".join(chunks) == b"b"
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.asyncio
+async def test_serve_file_chunk_oserror_fallback():
+    with patch("asyncio.to_thread", side_effect=[OSError("bad"), 3]):
+        chunks = []
+        async for chunk in MMapFileHandler.serve_file_chunk("/nonexistent"):
+            chunks.append(chunk)
+        assert chunks == []
+
+
+def test_find_line_offsets_large_file():
+    from aird.constants import MMAP_MIN_SIZE
+
+    with tempfile.NamedTemporaryFile(delete=False) as fh:
+        fh.write(b"0" * (MMAP_MIN_SIZE + 10))
+        path = fh.name
+    try:
+        offsets = MMapFileHandler.find_line_offsets(path, max_lines=1)
+        assert offsets == [0]
+    finally:
+        os.unlink(path)
+
+
+def test_search_in_file():
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", encoding="utf-8") as fh:
+        fh.write("hello world\nneedle here\n")
+        path = fh.name
+    try:
+        hits = MMapFileHandler.search_in_file(path, "needle")
+        assert len(hits) >= 1
+    finally:
+        os.unlink(path)

--- a/tests/test_mmap_extended.py
+++ b/tests/test_mmap_extended.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from unittest.mock import patch
 
 import pytest
 
@@ -53,19 +54,11 @@ async def test_serve_file_chunk_empty_tail():
         os.unlink(path)
 
 
-@pytest.mark.asyncio
-async def test_serve_file_chunk_oserror_fallback():
-    with patch("asyncio.to_thread", side_effect=[OSError("bad"), 3]):
-        chunks = []
-        async for chunk in MMapFileHandler.serve_file_chunk("/nonexistent"):
-            chunks.append(chunk)
-        assert chunks == []
-
-
 def test_find_line_offsets_large_file():
     from aird.constants import MMAP_MIN_SIZE
 
     with tempfile.NamedTemporaryFile(delete=False) as fh:
+        fh.write(b"\n")
         fh.write(b"0" * (MMAP_MIN_SIZE + 10))
         path = fh.name
     try:

--- a/tests/test_quick_win_coverage.py
+++ b/tests/test_quick_win_coverage.py
@@ -1,0 +1,955 @@
+"""Targeted tests for modules with low coverage (quick wins)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from aird.app_context import AppContext
+from aird.core.events import (
+    EventBus,
+    PolicyDecisionEvent,
+    ShareCreatedEvent,
+    TransferStartedEvent,
+    UserAuthenticatedEvent,
+    now_ts,
+)
+from aird.core.input_validation import (
+    bound_access_token,
+    bound_login_password,
+    bound_username_for_login,
+    require_max_chars,
+    validate_abac_tag_rule,
+    validate_policy_payload,
+    validate_share_create_struct,
+    validate_share_update_struct,
+    validate_super_search_glob,
+    validate_user_attribute,
+    validate_ws_search,
+)
+from aird.core.share_root import (
+    creator_folder_username_from_share_field,
+    filesystem_root_for_share,
+    login_matches_share_creator_field,
+)
+from aird.db import init_db
+from aird.db.audit import get_audit_logs, log_audit
+from aird.db.favorites import get_user_favorites, toggle_favorite
+from aird.db.policies import (
+    delete_policy,
+    get_policy,
+    get_policy_by_name,
+    insert_policy,
+    list_policies,
+    update_policy,
+)
+from aird.db.policy_decisions import get_policy_decisions, log_policy_decision
+from aird.db.quota import get_user_quota, set_user_quota, update_user_used_bytes
+from aird.db.ranged_uploads import (
+    create_session,
+    delete_session,
+    get_session,
+    update_ranges,
+)
+from aird.db.resource_tags import (
+    delete_resource_tag,
+    delete_resource_tag_by_name,
+    insert_resource_tag,
+    list_resource_tags,
+    update_resource_tag,
+)
+from aird.db.user_attributes import (
+    delete_user_attribute,
+    get_user_attributes,
+    list_all_user_attributes,
+    set_user_attribute,
+)
+from aird.event_loop import install_uvloop_if_linux
+from aird.handlers.health_handler import HealthHandler
+from aird.server_runtime import (
+    describe_worker_layout,
+    detect_physical_cpu_count,
+    detect_threads_per_core,
+    resolve_worker_count,
+)
+from aird.services.audit_service import AuditService
+from aird.services.config_service import ConfigService
+from aird.services.email_subscriber import EmailNotificationSubscriber
+from aird.services.event_subscribers import (
+    EventLoggingSubscriber,
+    EventMetricsSubscriber,
+    PolicyDecisionMetricsSubscriber,
+)
+from aird.services.favorites_service import FavoritesService
+from aird.services.network_share_service import NetworkShareService
+from aird.services.quota_service import QuotaService
+from aird.sql_identifiers import (
+    format_select_columns,
+    format_shares_select_by_id_sql,
+    format_shares_select_sql,
+    format_update_by_id_sql,
+)
+from aird.constants.input_limits import InputTooLongError
+from tests.handler_helpers import _default_services, authenticate, patch_db_conn, prepare_handler
+
+
+@pytest.fixture
+def db_conn():
+    conn = sqlite3.connect(":memory:")
+    init_db(conn)
+    yield conn
+    conn.close()
+
+
+class TestInputValidation:
+  def test_require_max_chars(self):
+      assert require_max_chars(None, max_len=10) == ""
+      assert require_max_chars("  hi  ", max_len=10) == "  hi  "
+      with pytest.raises(InputTooLongError):
+          require_max_chars("x" * 11, max_len=10, field="name")
+
+  def test_bound_login_fields(self):
+      handler = MagicMock()
+      handler.get_argument.side_effect = lambda k, default="": {
+          "username": " alice ",
+          "password": "secret",
+          "token": "tok",
+      }.get(k, default)
+      assert bound_username_for_login(handler) == "alice"
+      assert bound_login_password(handler) == "secret"
+      assert bound_access_token(handler) == "tok"
+
+  def test_bound_fields_too_long(self):
+      handler = MagicMock()
+      handler.get_argument.return_value = "x" * 50_000
+      with pytest.raises(InputTooLongError):
+          bound_username_for_login(handler)
+      with pytest.raises(InputTooLongError):
+          bound_login_password(handler)
+      with pytest.raises(InputTooLongError):
+          bound_access_token(handler)
+
+  def test_validate_ws_search(self):
+      assert validate_ws_search("*.txt", "needle") == ("*.txt", "needle")
+      with pytest.raises(InputTooLongError):
+          validate_ws_search("x" * 5000, "")
+
+  def test_validate_super_search_glob(self):
+      assert validate_super_search_glob("*.pdf") is None
+      assert validate_super_search_glob("") == "pattern is empty"
+      assert validate_super_search_glob("//abs") == "pattern must not be an absolute or UNC-style path"
+      assert validate_super_search_glob("C:foo") == "patterns with a drive letter are not allowed"
+      assert validate_super_search_glob("a/../b") == "pattern must not contain '..' path segments"
+      assert validate_super_search_glob("a\x00b") == "pattern contains invalid characters"
+
+  def test_validate_abac_and_policy(self):
+      validate_abac_tag_rule("tag", "*.txt")
+      with pytest.raises(InputTooLongError):
+          validate_abac_tag_rule("x" * 200, "p")
+      with pytest.raises(InputTooLongError):
+          validate_policy_payload("n" * 300, "", [], {})
+
+  def test_validate_share_create_struct(self):
+      assert validate_share_create_struct({"share_type": "tag", "tag_name": "docs"}) is None
+      assert validate_share_create_struct({"share_type": "tag", "tag_name": "x" * 200}) == "tag_name too long"
+      assert validate_share_create_struct({"paths": "bad"}) == "paths must be a list"
+      assert validate_share_create_struct({"paths": ["ok"], "allowed_users": "bad"}) == "allowed_users must be a list"
+
+  def test_validate_share_update_struct(self):
+      assert validate_share_update_struct({"share_id": "x" * 300}) == "share_id too long"
+      assert validate_share_update_struct({"disable_token": "yes"}) == "disable_token must be a boolean"
+      assert validate_share_update_struct({"rotate_token": 1}) == "rotate_token must be a boolean"
+      assert validate_share_update_struct({"remove_files": "nope"}) == "remove_files must be a list"
+      assert validate_share_update_struct({}) is None
+
+  def test_validate_user_attribute(self):
+      validate_user_attribute("user", "dept", "eng")
+      with pytest.raises(InputTooLongError):
+          validate_user_attribute("u" * 500, "k", "v")
+
+
+class TestShareRoot:
+  def test_login_matches_share_creator_field(self):
+      assert login_matches_share_creator_field("alice", "alice") is True
+      assert login_matches_share_creator_field("alice (Admin)", "alice") is True
+      assert login_matches_share_creator_field(None, "alice") is False
+      assert login_matches_share_creator_field("", "alice") is False
+      assert login_matches_share_creator_field("bob", "alice") is False
+
+  def test_creator_folder_username_from_share_field(self):
+      assert creator_folder_username_from_share_field("alice (User)") == "alice"
+      assert creator_folder_username_from_share_field("Admin (Token)") == ""
+      assert creator_folder_username_from_share_field("plain") == "plain"
+
+  def test_filesystem_root_for_share(self, temp_dir):
+      import aird.constants as constants
+
+      with patch.object(constants, "MULTI_USER", False), patch.object(
+          constants, "ROOT_DIR", temp_dir
+      ):
+          assert filesystem_root_for_share({"created_by": "alice"}) == temp_dir
+
+      with patch.object(constants, "MULTI_USER", True), patch.object(
+          constants, "ROOT_DIR", temp_dir
+      ):
+          root = filesystem_root_for_share({"created_by": "alice (User)"})
+          assert root.endswith("alice")
+          assert filesystem_root_for_share({"created_by": "token_user"}) == temp_dir
+
+
+class TestDbFavoritesQuota:
+  def test_favorites_toggle_and_list(self, db_conn):
+      assert toggle_favorite(None, "u", "/a") is False
+      assert get_user_favorites(None, "u") == []
+      assert toggle_favorite(db_conn, "alice", "/docs/a.pdf") is True
+      assert toggle_favorite(db_conn, "alice", "/docs/a.pdf") is False
+      assert toggle_favorite(db_conn, "alice", "/docs/b.pdf") is True
+      assert get_user_favorites(db_conn, "alice") == ["/docs/b.pdf"]
+
+  def test_quota_operations(self, db_conn):
+      from aird.db.users import create_user
+
+      create_user(db_conn, "quota_user", "hash", role="user")
+      assert get_user_quota(None, "x") == {"quota_bytes": None, "used_bytes": 0}
+      set_user_quota(db_conn, "quota_user", 1000)
+      update_user_used_bytes(db_conn, "quota_user", 250)
+      info = get_user_quota(db_conn, "quota_user")
+      assert info["quota_bytes"] == 1000
+      assert info["used_bytes"] == 250
+      update_user_used_bytes(None, "quota_user", 10)
+
+
+class TestDbRangedUploads:
+  def test_session_lifecycle(self, db_conn):
+      create_session(
+          db_conn,
+          session_id="sess-1",
+          username="alice",
+          upload_dir="/tmp",
+          filename="big.bin",
+          temp_path="/tmp/big.bin.part",
+          total_size=100,
+      )
+      session = get_session(db_conn, "sess-1")
+      assert session is not None
+      assert session["total_size"] == 100
+      assert session["ranges"] == []
+      from aird.core.http_range import ByteRange
+
+      update_ranges(db_conn, "sess-1", [ByteRange(0, 49)])
+      session = get_session(db_conn, "sess-1")
+      assert len(session["ranges"]) == 1
+      delete_session(db_conn, "sess-1")
+      assert get_session(db_conn, "sess-1") is None
+
+
+class TestDbUserAttributes:
+  def test_user_attributes_crud(self, db_conn):
+      assert set_user_attribute(None, "u", "k", "v") is False
+      assert set_user_attribute(db_conn, "", "k", "v") is False
+      assert set_user_attribute(db_conn, "alice", "dept", "eng") is True
+      assert get_user_attributes(db_conn, "alice") == {"dept": "eng"}
+      assert set_user_attribute(db_conn, "alice", "dept", "sales") is True
+      assert delete_user_attribute(db_conn, "alice", "dept") is True
+      assert delete_user_attribute(db_conn, "alice", "missing") is False
+      rows = list_all_user_attributes(db_conn)
+      assert isinstance(rows, list)
+
+
+class TestDbPolicyDecisions:
+  def test_log_and_query(self, db_conn):
+      assert log_policy_decision(None, username="u", action="read", decision="permit") is None
+      row_id = log_policy_decision(
+          db_conn,
+          username="alice",
+          action="read",
+          decision="permit",
+          resource="/a.txt",
+          reason="ok",
+          policy_id=1,
+          attributes={"role": "user"},
+          ip="127.0.0.1",
+      )
+      assert row_id is not None
+      all_rows = get_policy_decisions(db_conn)
+      assert len(all_rows) == 1
+      assert all_rows[0]["attributes"] == {"role": "user"}
+      deny_rows = get_policy_decisions(db_conn, decision="deny")
+      assert deny_rows == []
+      user_rows = get_policy_decisions(db_conn, username="alice", decision="permit")
+      assert len(user_rows) == 1
+
+
+class TestDbPolicies:
+  def test_policy_crud(self, db_conn):
+      assert insert_policy(None, name="p", effect="permit", target_actions=[], condition={}) is None
+      pid = insert_policy(
+          db_conn,
+          name="allow-read",
+          effect="permit",
+          target_actions=["read"],
+          condition={"role": "user"},
+          description="desc",
+          priority=5,
+      )
+      assert pid is not None
+      policy = get_policy(db_conn, pid)
+      assert policy["name"] == "allow-read"
+      assert get_policy_by_name(db_conn, "allow-read")["id"] == pid
+      assert update_policy(db_conn, pid, description="updated", enabled=False) is True
+      assert update_policy(db_conn, pid, effect="invalid") is False
+      assert delete_policy(db_conn, pid) is True
+      assert delete_policy(None, 1) is False
+      assert get_policy(None, 1) is None
+      assert list_policies(None) == []
+
+
+class TestDbResourceTags:
+  def test_resource_tags_crud(self, db_conn):
+      assert insert_resource_tag(None, "conf", "*.secret") is None
+      tag_id = insert_resource_tag(db_conn, "conf", "*.secret", priority=2, created_by="admin")
+      assert tag_id is not None
+      tags = list_resource_tags(db_conn)
+      assert len(tags) == 1
+      assert update_resource_tag(db_conn, tag_id, tag="classified") is True
+      assert delete_resource_tag(db_conn, tag_id) is True
+      tag_id2 = insert_resource_tag(db_conn, "tmp", "*.tmp")
+      assert delete_resource_tag_by_name(db_conn, "tmp") == 1
+
+
+class TestDbResourceTagsErrors:
+  def test_resource_tag_guard_paths(self, db_conn):
+      assert insert_resource_tag(db_conn, "", "*.x") is None
+      assert delete_resource_tag(None, 1) is False
+      assert delete_resource_tag_by_name(None, "t") == 0
+      assert update_resource_tag(db_conn, 99999, tag="nope") is False
+      assert list_resource_tags(None) == []
+
+
+class TestDbAudit:
+  def test_audit_log(self, db_conn):
+      log_audit(None, "noop")
+      log_audit(db_conn, "login", username="alice", details="ok", ip="1.2.3.4")
+      logs = get_audit_logs(db_conn, limit=10)
+      assert logs[0]["action"] == "login"
+      assert get_audit_logs(None) == []
+
+  def test_audit_log_write_failure(self, db_conn):
+      broken = MagicMock()
+      broken.execute.side_effect = RuntimeError("db")
+      log_audit(broken, "x")
+
+
+class TestServices:
+  def test_favorites_and_quota_services(self, db_conn):
+      fav = FavoritesService()
+      assert fav.toggle(db_conn, "alice", "/x") is True
+      assert fav.get_favorites(db_conn, "alice") == ["/x"]
+      quota = QuotaService()
+      from aird.db.users import create_user
+
+      create_user(db_conn, "q2", "hash")
+      quota.update_used_bytes(db_conn, "q2", 42)
+      assert quota.get_quota(db_conn, "q2")["used_bytes"] == 42
+
+  def test_audit_service(self, db_conn):
+      svc = AuditService()
+      svc.log(db_conn, "action", username="u")
+      assert len(svc.get_logs(db_conn)) == 1
+
+  def test_config_service_merge_from_db(self, db_conn):
+      import aird.constants as constants
+      from aird.db.config import save_allowed_extensions, save_feature_flags, save_upload_config
+
+      save_feature_flags(db_conn, {"favorites": 1})
+      save_upload_config(db_conn, {"max_file_size_mb": 10})
+      save_allowed_extensions(db_conn, {".txt"})
+      svc = ConfigService()
+      svc.merge_from_db(db_conn)
+      assert constants.FEATURE_FLAGS["favorites"] is True
+      assert constants.MAX_FILE_SIZE == 10 * 1024 * 1024
+      assert ".txt" in constants.UPLOAD_ALLOWED_EXTENSIONS
+
+  def test_network_share_service(self, db_conn):
+      svc = NetworkShareService()
+      manager = svc.build_manager()
+      assert manager is not None
+      svc.auto_start_enabled(db_conn, manager)
+      assert svc.list_all(db_conn) == []
+
+
+class TestEventSubscribers:
+  def test_metrics_and_logging(self):
+      metrics = EventMetricsSubscriber()
+      metrics.on_user_authenticated(
+          UserAuthenticatedEvent("u", "user", "127.0.0.1", now_ts())
+      )
+      metrics.on_share_created(
+          ShareCreatedEvent("s1", "alice", 2, now_ts())
+      )
+      metrics.on_transfer_started(
+          TransferStartedEvent("r1", "alice", False, now_ts())
+      )
+      snap = metrics.snapshot()
+      assert snap["user_authenticated"] == 1
+
+      logging_sub = EventLoggingSubscriber()
+      logging_sub.on_user_authenticated(
+          UserAuthenticatedEvent("u", "user", "127.0.0.1", now_ts())
+      )
+      logging_sub.on_share_created(
+          ShareCreatedEvent("s1", "alice", 2, now_ts())
+      )
+      logging_sub.on_transfer_started(
+          TransferStartedEvent("r1", "alice", False, now_ts())
+      )
+      logging_sub.on_policy_decision(
+          PolicyDecisionEvent("u", "read", "/a", "permit", "ok", 1, "p", None, now_ts())
+      )
+
+      pdm = PolicyDecisionMetricsSubscriber()
+      pdm.on_policy_decision(
+          PolicyDecisionEvent("u", "read", "/a", "permit", "ok", 1, "p", None, now_ts())
+      )
+      assert pdm.snapshot()["policy_permit"] == 1
+
+  def test_event_bus_handles_subscriber_errors(self):
+      bus = EventBus()
+
+      def bad_handler(_event):
+          raise RuntimeError("boom")
+
+      bus.subscribe(UserAuthenticatedEvent, bad_handler)
+      bus.publish(UserAuthenticatedEvent("u", "user", "ip", now_ts()))
+
+
+class TestEmailSubscriber:
+  def test_share_created_disabled(self):
+      email = MagicMock()
+      email.enabled = False
+      sub = EmailNotificationSubscriber(email_service=email)
+      sub.on_share_created(
+          ShareCreatedEvent("s1", "alice", 1, now_ts(), allowed_users=("bob",))
+      )
+      email.notify_share_created.assert_not_called()
+
+  def test_deliver_share_created(self):
+      email = MagicMock()
+      email.enabled = True
+      email.notify_share_created.return_value = 2
+      sub = EmailNotificationSubscriber(
+          email_service=email, db_conn_getter=lambda: object()
+      )
+      sub._deliver_share_created(
+          ShareCreatedEvent("s1", "alice", 1, now_ts(), modify_users=("bob",))
+      )
+      email.notify_share_created.assert_called_once()
+
+  def test_deliver_share_created_logs_exception(self):
+      email = MagicMock()
+      email.enabled = True
+      email.notify_share_created.side_effect = RuntimeError("smtp down")
+      sub = EmailNotificationSubscriber(
+          email_service=email, db_conn_getter=lambda: object()
+      )
+      sub._deliver_share_created(
+          ShareCreatedEvent("s1", "alice", 1, now_ts())
+      )
+
+
+class TestNetworkShareServiceExtended:
+  def test_auto_start_enabled_shares(self, db_conn):
+      from aird.db.network_shares import create_network_share
+      from aird.services.network_share_service import NetworkShareService
+
+      create_network_share(
+          db_conn,
+          "ns1",
+          "smb1",
+          "/tmp",
+          "smb",
+          445,
+          "user",
+          "pass",
+      )
+      svc = NetworkShareService()
+      manager = MagicMock()
+      svc.auto_start_enabled(db_conn, manager)
+      manager.start_share.assert_called_once()
+
+  def test_health_ok(self):
+      handler = HealthHandler(MagicMock(), MagicMock())
+      prepare_handler(handler)
+      with patch("aird.handlers.health_handler.constants_module.DB_CONN", None):
+          handler.get()
+      handler.set_status.assert_not_called()
+      payload = handler.write.call_args[0][0]
+      assert payload["status"] == "ok"
+      assert payload["db"] == "not_configured"
+
+  def test_health_db_ok(self, db_conn):
+      handler = HealthHandler(MagicMock(), MagicMock())
+      prepare_handler(handler)
+      with patch("aird.handlers.health_handler.constants_module.DB_CONN", db_conn):
+          handler.get()
+      handler.set_status.assert_not_called()
+      assert handler.write.call_args[0][0]["db"] == "ok"
+
+  def test_health_db_error(self):
+      handler = HealthHandler(MagicMock(), MagicMock())
+      prepare_handler(handler)
+      broken = MagicMock()
+      broken.execute.side_effect = sqlite3.OperationalError("db down")
+      with patch("aird.handlers.health_handler.constants_module.DB_CONN", broken):
+          handler.get()
+      handler.set_status.assert_called_once_with(503)
+      payload = handler.write.call_args[0][0]
+      assert payload["status"] == "error"
+      assert payload["db"] == "error"
+
+
+class TestEventLoop:
+  def test_install_uvloop_paths(self):
+      import aird.event_loop as el
+
+      el._uvloop_installed = False
+      with patch("aird.event_loop.sys.platform", "darwin"):
+          assert install_uvloop_if_linux() is False
+      el._uvloop_installed = False
+      with patch("aird.event_loop.sys.platform", "linux"), patch.dict(
+          "sys.modules", {"uvloop": None}
+      ):
+          with patch("builtins.__import__", side_effect=ImportError("no uvloop")):
+              assert install_uvloop_if_linux() is False
+      el._uvloop_installed = False
+      with patch("aird.event_loop.sys.platform", "linux"), patch(
+          "uvloop.EventLoopPolicy"
+      ), patch("asyncio.set_event_loop_policy") as set_policy:
+          assert install_uvloop_if_linux() is True
+          set_policy.assert_called_once()
+      el._uvloop_installed = True
+      assert install_uvloop_if_linux() is True
+
+      el._uvloop_installed = False
+      with patch("aird.event_loop.sys.platform", "linux"), patch(
+          "asyncio.set_event_loop_policy", side_effect=RuntimeError("fail")
+      ):
+          assert install_uvloop_if_linux() is False
+
+
+class TestServerRuntimeExtended:
+  def test_detect_threads_per_core_env(self):
+      with patch.dict("os.environ", {"AIRD_THREADS_PER_CORE": "4"}):
+          assert detect_threads_per_core() == 4.0
+      with patch.dict("os.environ", {"AIRD_THREADS_PER_CORE": "bad"}):
+          assert detect_threads_per_core() == 2.0
+
+  def test_detect_physical_cpu_count_linux_proc(self):
+      cpuinfo = "core id\t: 0\ncore id\t: 1\n"
+      with patch("aird.server_runtime.sys.platform", "linux"), patch(
+          "builtins.open", mock_open(read_data=cpuinfo)
+      ):
+          assert detect_physical_cpu_count() == 2
+
+  def test_resolve_worker_count_env(self):
+      with patch("aird.server_runtime.sys.platform", "linux"), patch.dict(
+          "os.environ", {"AIRD_WORKERS": "5"}
+      ):
+          assert resolve_worker_count() == 5
+      with patch("aird.server_runtime.sys.platform", "linux"), patch.dict(
+          "os.environ", {"AIRD_WORKERS": "0"}
+      ), patch("aird.server_runtime.compute_default_worker_count", return_value=3):
+          assert resolve_worker_count() == 3
+
+  def test_describe_worker_layout(self):
+      text = describe_worker_layout(4)
+      assert "workers=4" in text
+
+
+class TestSqlIdentifiers:
+  def test_format_helpers(self):
+      allowed = frozenset({"id", "name"})
+      assert format_select_columns(["id", "name"], allowed) == "id, name"
+      with pytest.raises(ValueError):
+          format_select_columns(["id", "evil"], allowed)
+      sql = format_update_by_id_sql("users", "name = ?")
+      assert "UPDATE users SET name = ? WHERE id = ?" == sql
+      with pytest.raises(ValueError):
+          format_update_by_id_sql("evil", "x = ?")
+      assert format_shares_select_sql("id") == "SELECT id FROM shares"
+      assert format_shares_select_by_id_sql("id") == "SELECT id FROM shares WHERE id = ?"
+
+
+class TestAppContext:
+  def test_service_accessors(self):
+      ctx = AppContext(services={"audit_service": AuditService()})
+      assert ctx.get_service("missing", 42) == 42
+      assert ctx.audit_service is not None
+      assert ctx.config_service is None
+      assert ctx.favorites_service is None
+      assert ctx.network_share_service is None
+      assert ctx.p2p_signaling_service is None
+      assert ctx.quota_service is None
+      assert ctx.share_service is None
+      assert ctx.user_service is None
+      assert ctx.tag_service is None
+      assert ctx.policy_service is None
+
+
+class TestDbWebAuthn:
+  def test_webauthn_lifecycle(self, db_conn):
+      from aird.db.webauthn import (
+          CHALLENGE_TTL_SECONDS,
+          consume_challenge,
+          create_credential,
+          credential_id_to_b64,
+          delete_credential,
+          ensure_prf_salt,
+          get_credential_by_credential_id,
+          get_credential_by_id,
+          get_prf_salt,
+          list_credentials,
+          store_challenge,
+          update_sign_count,
+      )
+
+      from datetime import datetime, timezone
+
+      def _now_iso() -> str:
+          return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+      challenge = b"challenge-bytes-12345"
+      assert store_challenge(None, challenge, "register") is False
+      with patch("aird.db.webauthn._utcnow_iso", side_effect=_now_iso):
+          assert store_challenge(db_conn, challenge, "register", username="alice") is True
+          assert consume_challenge(db_conn, challenge, "register") == "alice"
+      assert consume_challenge(db_conn, challenge, "register") is None
+
+      cred_id = credential_id_to_b64(b"cred-id-bytes")
+      assert create_credential(
+          db_conn,
+          username="alice",
+          credential_id=cred_id,
+          public_key=b"pk",
+          sign_count=0,
+          transports="usb",
+          aaguid=None,
+          prf_capable=True,
+          nickname="key",
+      )
+      creds = list_credentials(db_conn, "alice")
+      assert len(creds) == 1
+      row = get_credential_by_id(db_conn, creds[0]["id"], "alice")
+      assert row["credential_id"] == cred_id
+      assert get_credential_by_credential_id(db_conn, cred_id)["username"] == "alice"
+      assert update_sign_count(db_conn, creds[0]["id"], 1) is True
+      salt = ensure_prf_salt(db_conn, "alice")
+      assert salt
+      assert get_prf_salt(db_conn, "alice") == salt
+      assert delete_credential(db_conn, creds[0]["id"], "alice") is True
+
+  def test_webauthn_error_paths(self, db_conn):
+      from aird.db.webauthn import consume_challenge, create_credential, list_credentials
+
+      assert list_credentials(None, "alice") == []
+      assert create_credential(
+          db_conn, username="", credential_id="x", public_key=b"k", sign_count=0,
+          transports=None, aaguid=None, prf_capable=False
+      ) is False
+      assert consume_challenge(db_conn, b"", "auth") is None
+
+
+class TestDbPolicyDecisionsExtended:
+  def test_malformed_attributes_json(self, db_conn):
+      from datetime import datetime, timezone
+
+      created = datetime.now(timezone.utc).isoformat() + "Z"
+      db_conn.execute(
+          "INSERT INTO policy_decisions "
+          "(created_at, username, action, resource, decision, reason, policy_id, attributes_json, ip) "
+          "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          (created, "u", "read", None, "permit", None, None, "not-json", None),
+      )
+      db_conn.commit()
+      rows = get_policy_decisions(db_conn)
+      assert rows[0]["attributes"] is None
+
+
+class TestDbSharesCoverage:
+  def test_share_covers_paths(self, db_conn, temp_dir):
+      import os
+
+      from aird.db.resource_tags import insert_resource_tag
+      from aird.db.shares import (
+          get_share_download_count,
+          list_files_for_tag_share,
+          list_shares_accessible_to_user,
+          share_covers_relative_path,
+          share_paths_cover_target,
+      )
+
+      os.makedirs(os.path.join(temp_dir, "docs"), exist_ok=True)
+      with open(os.path.join(temp_dir, "docs", "a.txt"), "w", encoding="utf-8") as fh:
+          fh.write("x")
+      with open(os.path.join(temp_dir, "readme.txt"), "w", encoding="utf-8") as fh:
+          fh.write("y")
+
+      static = {"share_type": "static", "paths": ["docs/a.txt"], "allow_list": [], "avoid_list": []}
+      assert share_covers_relative_path(db_conn, static, "docs/a.txt", temp_dir)
+      assert share_paths_cover_target(["docs/a.txt"], "docs") is True
+
+      dynamic = {"share_type": "dynamic", "paths": ["docs"], "allow_list": [], "avoid_list": []}
+      assert share_covers_relative_path(db_conn, dynamic, "docs/a.txt", temp_dir)
+
+      insert_resource_tag(db_conn, "docs", "*.txt")
+      tag_share = {
+          "share_type": "tag",
+          "tag_name": "docs",
+          "allow_list": [],
+          "avoid_list": [],
+      }
+      assert share_covers_relative_path(db_conn, tag_share, "docs/a.txt", temp_dir)
+      files = list_files_for_tag_share(db_conn, "docs", temp_dir, [], [])
+      assert "docs/a.txt" in files
+
+      from aird.db.shares import insert_share
+
+      insert_share(
+          db_conn,
+          "s1",
+          "2024-01-01T00:00:00Z",
+          ["readme.txt"],
+          allowed_users=["bob"],
+      )
+      accessible = list_shares_accessible_to_user(db_conn, "bob")
+      assert len(accessible) == 1
+
+      insert_share(
+          db_conn,
+          "s2",
+          "2024-01-01T00:00:00Z",
+          ["other.txt"],
+          allowed_users=["bob"],
+          created_by="bob",
+      )
+      assert list_shares_accessible_to_user(db_conn, "bob") == accessible
+      from aird.db.audit import log_audit
+
+      log_audit(db_conn, "share_download", details="share_id=s1 user=bob")
+      assert get_share_download_count(db_conn, "s1") == 1
+
+
+class TestFileOperationsGlobs:
+  def test_double_star_glob_patterns(self):
+      from aird.core.file_operations import filter_files_by_patterns, matches_glob_patterns
+
+      files = ["a.py", "src/a.py", "src/deep/a.py", "readme.md"]
+      assert matches_glob_patterns("src/a.py", ["**/*.py"])
+      assert filter_files_by_patterns(files, allow_list=["**/*.py"]) == [
+          "a.py",
+          "src/a.py",
+          "src/deep/a.py",
+      ]
+      assert matches_glob_patterns("docs", ["docs/**"])
+      assert matches_glob_patterns("docs/x", ["docs/**"])
+
+
+class TestFileOperationsScan:
+  def test_get_all_files_recursive(self, temp_dir):
+      import os
+
+      from aird.core.file_operations import get_all_files_recursive
+
+      os.makedirs(os.path.join(temp_dir, "sub"), exist_ok=True)
+      with open(os.path.join(temp_dir, "root.txt"), "w", encoding="utf-8") as fh:
+          fh.write("a")
+      with open(os.path.join(temp_dir, "sub", "nested.txt"), "w", encoding="utf-8") as fh:
+          fh.write("b")
+      files = get_all_files_recursive(temp_dir)
+      assert "root.txt" in files
+      assert os.path.join("sub", "nested.txt") in files
+
+  def test_get_all_files_os_error(self):
+      from aird.core.file_operations import get_all_files_recursive
+
+      with patch("os.listdir", side_effect=OSError("nope")):
+          assert get_all_files_recursive("/bad/path") == []
+
+
+class TestRangedUploadHandler:
+  def test_post_validation_errors(self):
+      from aird.handlers.ranged_upload_handlers import RangedUploadSessionHandler
+
+      app = MagicMock()
+      app.settings = {"services": _default_services()}
+      req = MagicMock()
+      req.body = b"not-json"
+      req.remote_ip = "127.0.0.1"
+      req.connection = MagicMock()
+      req.connection.context = MagicMock()
+      handler = RangedUploadSessionHandler(app, req)
+      authenticate(handler)
+      prepare_handler(handler)
+
+      with patch.object(handler, "require_feature", return_value=True), patch(
+          "aird.handlers.ranged_upload_handlers.is_feature_enabled", return_value=True
+      ):
+          import asyncio
+
+          asyncio.get_event_loop().run_until_complete(handler.post())
+      handler.set_status.assert_called_with(400)
+      import asyncio
+
+      import aird.constants as constants
+      from aird.handlers.ranged_upload_handlers import RangedUploadSessionHandler
+
+      app = MagicMock()
+      app.settings = {"services": _default_services()}
+      req = MagicMock()
+      req.body = json.dumps(
+          {"filename": "tiny.txt", "total_size": 10, "upload_dir": ""}
+      ).encode()
+      req.remote_ip = "127.0.0.1"
+      req.connection = MagicMock()
+      req.connection.context = MagicMock()
+      handler = RangedUploadSessionHandler(app, req)
+      authenticate(handler)
+      prepare_handler(handler)
+
+      with patch_db_conn(db_conn), patch.object(
+          handler, "require_feature", return_value=True
+      ), patch(
+          "aird.handlers.ranged_upload_handlers.is_feature_enabled", return_value=True
+      ), patch.object(
+          constants, "LARGE_FILE_THRESHOLD_BYTES", 100
+      ):
+          asyncio.get_event_loop().run_until_complete(handler.post())
+      handler.set_status.assert_called_with(400)
+
+
+class TestRangedUploadSessionSuccess:
+  def test_create_session(self, db_conn, temp_dir):
+      import asyncio
+
+      import aird.constants as constants
+      from aird.handlers.ranged_upload_handlers import RangedUploadSessionHandler
+
+      app = MagicMock()
+      app.settings = {"services": _default_services()}
+      req = MagicMock()
+      req.body = json.dumps(
+          {
+              "filename": "big.bin",
+              "total_size": constants.LARGE_FILE_THRESHOLD_BYTES + 1000,
+              "upload_dir": "",
+          }
+      ).encode()
+      req.remote_ip = "127.0.0.1"
+      req.connection = MagicMock()
+      req.connection.context = MagicMock()
+      handler = RangedUploadSessionHandler(app, req)
+      authenticate(handler)
+      prepare_handler(handler)
+      handler.get_display_username = MagicMock(return_value="alice")
+
+      with patch_db_conn(db_conn), patch.object(
+          handler, "require_feature", return_value=True
+      ), patch(
+          "aird.handlers.ranged_upload_handlers.is_feature_enabled", return_value=True
+      ), patch(
+          "aird.handlers.ranged_upload_handlers.get_user_root", return_value=temp_dir
+      ), patch.object(constants, "MAX_FILE_SIZE", 1024 * 1024 * 1024):
+          asyncio.get_event_loop().run_until_complete(handler.post())
+      handler.set_status.assert_called_with(201)
+      payload = handler.write.call_args[0][0]
+      assert "upload_id" in payload
+
+
+class TestCliAuthelia:
+  def test_needs_second_factor(self):
+      from aird.cli.authelia import AutheliaError, _needs_second_factor, login, second_factor
+
+      assert _needs_second_factor({"status": "OK", "data": {}}) is False
+      assert _needs_second_factor({"status": "OK", "data": {"methods": ["totp"]}}) is True
+      assert _needs_second_factor({"status": "Unauthorized"}) is True
+
+      session = MagicMock()
+      response = MagicMock()
+      response.status_code = 200
+      response.json.return_value = {"status": "OK", "data": {}}
+      session.post.return_value = response
+      login(session, "https://auth.example", "alice", "secret")
+
+      response.json.return_value = {"status": "OK", "data": {"methods": ["totp"]}}
+      with pytest.raises(AutheliaError, match="second_factor_required"):
+          login(session, "https://auth.example", "alice", "secret")
+
+      response.status_code = 401
+      with pytest.raises(AutheliaError, match="rejected"):
+          login(session, "https://auth.example", "alice", "bad")
+
+      response.status_code = 200
+      response.json.return_value = {"status": "OK", "data": {"methods": ["totp"]}}
+      session.post.return_value = response
+      login(session, "https://auth.example", "alice", "secret", totp="123456")
+
+      bad_2fa = MagicMock()
+      bad_2fa.status_code = 401
+      session.post.return_value = bad_2fa
+      with pytest.raises(AutheliaError, match="one-time code"):
+          second_factor(session, "https://auth.example", "bad")
+
+  def test_login_non_json_response(self):
+      from aird.cli.authelia import AutheliaError, login
+
+      session = MagicMock()
+      response = MagicMock()
+      response.status_code = 200
+      response.json.side_effect = ValueError("not json")
+      session.post.return_value = response
+      with pytest.raises(AutheliaError, match="non-JSON"):
+          login(session, "https://auth.example", "alice", "secret")
+
+
+class TestInputValidationExtended:
+  def test_share_path_limits(self):
+      from aird.constants.input_limits import MAX_SHARE_PATHS, MAX_SHARE_PATH_STRING_LEN
+
+      too_many = {"paths": ["a"] * (MAX_SHARE_PATHS + 1)}
+      assert validate_share_create_struct(too_many) == "too many paths"
+      long_path = {"paths": ["x" * (MAX_SHARE_PATH_STRING_LEN + 10)]}
+      assert validate_share_create_struct(long_path) == "path too long"
+      assert validate_share_update_struct({"paths": [1, 2]}) == "paths entries must be strings or objects"
+      assert validate_share_update_struct({"allow_list": "bad"}) == "allow_list must be a list"
+
+  def test_policy_payload_limits(self):
+      from aird.constants.input_limits import MAX_POLICY_TARGET_ACTIONS
+
+      with pytest.raises(InputTooLongError):
+          validate_policy_payload(
+              "ok",
+              "",
+              ["a"] * (MAX_POLICY_TARGET_ACTIONS + 1),
+              {},
+          )
+
+
+class TestConstantsModule:
+  def test_read_app_version_fallback(self):
+      import aird.constants as constants
+
+      with patch("importlib.metadata.version", side_effect=Exception("no pkg")):
+          from aird.constants import _read_app_version
+
+          assert _read_app_version() in (constants.APP_VERSION, "0.4.24", "dev")
+
+  def test_get_static_version(self):
+      from aird.constants import get_static_version
+
+      v1 = get_static_version()
+      v2 = get_static_version()
+      assert v1
+      assert v1 == v2

--- a/tests/test_quick_win_coverage.py
+++ b/tests/test_quick_win_coverage.py
@@ -361,17 +361,29 @@ class TestServices:
       assert len(svc.get_logs(db_conn)) == 1
 
   def test_config_service_merge_from_db(self, db_conn):
+      import copy
+
       import aird.constants as constants
       from aird.db.config import save_allowed_extensions, save_feature_flags, save_upload_config
 
-      save_feature_flags(db_conn, {"favorites": 1})
-      save_upload_config(db_conn, {"max_file_size_mb": 10})
-      save_allowed_extensions(db_conn, {".txt"})
-      svc = ConfigService()
-      svc.merge_from_db(db_conn)
-      assert constants.FEATURE_FLAGS["favorites"] is True
-      assert constants.MAX_FILE_SIZE == 10 * 1024 * 1024
-      assert ".txt" in constants.UPLOAD_ALLOWED_EXTENSIONS
+      orig_upload = copy.deepcopy(constants.UPLOAD_CONFIG)
+      orig_max = constants.MAX_FILE_SIZE
+      orig_ext = set(constants.UPLOAD_ALLOWED_EXTENSIONS)
+      try:
+          save_feature_flags(db_conn, {"favorites": 1})
+          save_upload_config(db_conn, {"max_file_size_mb": 10})
+          save_allowed_extensions(db_conn, {".txt"})
+          svc = ConfigService()
+          svc.merge_from_db(db_conn)
+          assert constants.FEATURE_FLAGS["favorites"] is True
+          assert constants.MAX_FILE_SIZE == 10 * 1024 * 1024
+          assert ".txt" in constants.UPLOAD_ALLOWED_EXTENSIONS
+      finally:
+          constants.UPLOAD_CONFIG.clear()
+          constants.UPLOAD_CONFIG.update(orig_upload)
+          constants.MAX_FILE_SIZE = orig_max
+          constants.UPLOAD_ALLOWED_EXTENSIONS = orig_ext
+          constants.refresh_upload_derived_constants()
 
   def test_network_share_service(self, db_conn):
       svc = NetworkShareService()
@@ -799,7 +811,7 @@ class TestRangedUploadHandler:
       ):
           import asyncio
 
-          asyncio.get_event_loop().run_until_complete(handler.post())
+          asyncio.run(handler.post())
       handler.set_status.assert_called_with(400)
       import asyncio
 
@@ -826,7 +838,7 @@ class TestRangedUploadHandler:
       ), patch.object(
           constants, "LARGE_FILE_THRESHOLD_BYTES", 100
       ):
-          asyncio.get_event_loop().run_until_complete(handler.post())
+          asyncio.run(handler.post())
       handler.set_status.assert_called_with(400)
 
 
@@ -862,7 +874,7 @@ class TestRangedUploadSessionSuccess:
       ), patch(
           "aird.handlers.ranged_upload_handlers.get_user_root", return_value=temp_dir
       ), patch.object(constants, "MAX_FILE_SIZE", 1024 * 1024 * 1024):
-          asyncio.get_event_loop().run_until_complete(handler.post())
+          asyncio.run(handler.post())
       handler.set_status.assert_called_with(201)
       payload = handler.write.call_args[0][0]
       assert "upload_id" in payload
@@ -944,7 +956,7 @@ class TestConstantsModule:
       with patch("importlib.metadata.version", side_effect=Exception("no pkg")):
           from aird.constants import _read_app_version
 
-          assert _read_app_version() in (constants.APP_VERSION, "0.4.24", "dev")
+          assert _read_app_version() in (constants.APP_VERSION, "0.4.24", "0.4.25.dev3", "dev")
 
   def test_get_static_version(self):
       from aird.constants import get_static_version

--- a/tests/test_ranged_upload_handlers_extended.py
+++ b/tests/test_ranged_upload_handlers_extended.py
@@ -1,0 +1,255 @@
+"""Extended ranged upload handler tests."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aird.db import init_db
+from aird.db.ranged_uploads import create_session
+from aird.handlers.ranged_upload_handlers import (
+    RangedUploadChunkHandler,
+    RangedUploadStatusHandler,
+)
+from tests.handler_helpers import _default_services, authenticate, patch_db_conn, prepare_handler
+
+
+@pytest.fixture
+def db_conn():
+    import sqlite3
+
+    conn = sqlite3.connect(":memory:")
+    init_db(conn)
+    yield conn
+    conn.close()
+
+
+def _make_handler(handler_cls, body: bytes = b"", headers=None):
+    app = MagicMock()
+    app.settings = {"services": _default_services()}
+    req = MagicMock()
+    req.body = body
+    req.headers = headers or {}
+    req.arguments = {}
+    req.remote_ip = "127.0.0.1"
+    req.connection = MagicMock()
+    req.connection.context = MagicMock()
+    handler = handler_cls(app, req)
+    authenticate(handler, username="alice")
+    prepare_handler(handler)
+    handler.get_display_username = MagicMock(return_value="alice")
+    handler.get_cookie = MagicMock(return_value="xsrf")
+    req.headers.setdefault("X-XSRFToken", "xsrf")
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_chunk_handler_partial_upload(db_conn, temp_dir):
+    temp_path = os.path.join(temp_dir, "part.bin")
+    with open(temp_path, "wb") as fh:
+        fh.write(b"\x00" * 100)
+    create_session(
+        db_conn,
+        session_id="up-1",
+        username="alice",
+        upload_dir="",
+        filename="big.bin",
+        temp_path=temp_path,
+        total_size=100,
+    )
+    handler = _make_handler(
+        RangedUploadChunkHandler,
+        body=b"a" * 50,
+        headers={"Content-Range": "bytes 0-49/100", "X-XSRFToken": "xsrf"},
+    )
+    with patch_db_conn(db_conn), patch.object(
+        handler, "require_feature", return_value=True
+    ), patch("aird.handlers.ranged_upload_handlers.get_user_root", return_value=temp_dir):
+        await handler.put("up-1")
+    handler.set_status.assert_called_with(200)
+    payload = handler.write.call_args[0][0]
+    assert payload["status"] == "chunk_received"
+
+
+@pytest.mark.asyncio
+async def test_chunk_handler_completes_upload(db_conn, temp_dir):
+    temp_path = os.path.join(temp_dir, "full.bin")
+    with open(temp_path, "wb") as fh:
+        fh.write(b"\x00" * 20)
+    create_session(
+        db_conn,
+        session_id="up-2",
+        username="alice",
+        upload_dir="",
+        filename="done.bin",
+        temp_path=temp_path,
+        total_size=20,
+    )
+    handler = _make_handler(
+        RangedUploadChunkHandler,
+        body=b"x" * 20,
+        headers={"Content-Range": "bytes 0-19/20", "X-XSRFToken": "xsrf"},
+    )
+    with patch_db_conn(db_conn), patch.object(
+        handler, "require_feature", return_value=True
+    ), patch(
+        "aird.handlers.ranged_upload_handlers.get_user_root", return_value=temp_dir
+    ), patch(
+        "aird.handlers.ranged_upload_handlers.finalize_upload_to_disk",
+        return_value=(True, 201, "ok"),
+    ):
+        await handler.put("up-2")
+    handler.set_status.assert_called_with(201)
+    assert handler.write.call_args[0][0]["status"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_chunk_handler_errors(db_conn):
+    handler = _make_handler(
+        RangedUploadChunkHandler,
+        body=b"x",
+        headers={"X-XSRFToken": "xsrf"},
+    )
+    with patch_db_conn(db_conn), patch.object(handler, "require_feature", return_value=True):
+        await handler.put("missing")
+    handler.set_status.assert_called_with(404)
+
+
+@pytest.mark.asyncio
+async def test_status_handler(db_conn, temp_dir):
+    temp_path = os.path.join(temp_dir, "stat.bin")
+    open(temp_path, "wb").close()
+    create_session(
+        db_conn,
+        session_id="up-3",
+        username="alice",
+        upload_dir="",
+        filename="stat.bin",
+        temp_path=temp_path,
+        total_size=10,
+    )
+    handler = _make_handler(RangedUploadStatusHandler)
+    with patch_db_conn(db_conn):
+        await handler.get("up-3")
+    payload = handler.write.call_args[0][0]
+    assert payload["upload_id"] == "up-3"
+    assert payload["complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_chunk_wrong_user(db_conn, temp_dir):
+    temp_path = os.path.join(temp_dir, "part2.bin")
+    open(temp_path, "wb").close()
+    create_session(
+        db_conn,
+        session_id="up-4",
+        username="bob",
+        upload_dir="",
+        filename="x.bin",
+        temp_path=temp_path,
+        total_size=10,
+    )
+    handler = _make_handler(
+        RangedUploadChunkHandler,
+        body=b"x" * 5,
+        headers={"Content-Range": "bytes 0-4/10", "X-XSRFToken": "xsrf"},
+    )
+    with patch_db_conn(db_conn), patch.object(handler, "require_feature", return_value=True):
+        await handler.put("up-4")
+    handler.set_status.assert_called_with(403)
+
+
+@pytest.mark.asyncio
+async def test_chunk_bad_range(db_conn, temp_dir):
+    temp_path = os.path.join(temp_dir, "part3.bin")
+    open(temp_path, "wb").close()
+    create_session(
+        db_conn,
+        session_id="up-5",
+        username="alice",
+        upload_dir="",
+        filename="x.bin",
+        temp_path=temp_path,
+        total_size=10,
+    )
+    handler = _make_handler(
+        RangedUploadChunkHandler,
+        body=b"x",
+        headers={"X-XSRFToken": "xsrf"},
+    )
+    with patch_db_conn(db_conn), patch.object(handler, "require_feature", return_value=True):
+        await handler.put("up-5")
+    handler.set_status.assert_called_with(400)
+
+
+@pytest.mark.asyncio
+async def test_chunk_finalize_failure(db_conn, temp_dir):
+    temp_path = os.path.join(temp_dir, "part4.bin")
+    with open(temp_path, "wb") as fh:
+        fh.write(b"\x00" * 5)
+    create_session(
+        db_conn,
+        session_id="up-6",
+        username="alice",
+        upload_dir="",
+        filename="fail.bin",
+        temp_path=temp_path,
+        total_size=5,
+    )
+    handler = _make_handler(
+        RangedUploadChunkHandler,
+        body=b"x" * 5,
+        headers={"Content-Range": "bytes 0-4/5", "X-XSRFToken": "xsrf"},
+    )
+    with patch_db_conn(db_conn), patch.object(
+        handler, "require_feature", return_value=True
+    ), patch(
+        "aird.handlers.ranged_upload_handlers.get_user_root", return_value=temp_dir
+    ), patch(
+        "aird.handlers.ranged_upload_handlers.finalize_upload_to_disk",
+        return_value=(False, 500, "fail"),
+    ):
+        await handler.put("up-6")
+    handler.set_status.assert_called_with(500)
+
+
+def test_chunk_xsrf_required():
+    handler = _make_handler(RangedUploadChunkHandler)
+    handler.get_cookie = MagicMock(return_value=None)
+    with pytest.raises(Exception):
+        handler.check_xsrf_cookie()
+
+
+@pytest.mark.asyncio
+async def test_chunk_body_length_mismatch(db_conn, temp_dir):
+    temp_path = os.path.join(temp_dir, "part5.bin")
+    open(temp_path, "wb").close()
+    create_session(
+        db_conn,
+        session_id="up-7",
+        username="alice",
+        upload_dir="",
+        filename="x.bin",
+        temp_path=temp_path,
+        total_size=10,
+    )
+    handler = _make_handler(
+        RangedUploadChunkHandler,
+        body=b"short",
+        headers={"Content-Range": "bytes 0-9/10", "X-XSRFToken": "xsrf"},
+    )
+    with patch_db_conn(db_conn), patch.object(handler, "require_feature", return_value=True):
+        await handler.put("up-7")
+    handler.set_status.assert_called_with(400)
+
+
+@pytest.mark.asyncio
+async def test_status_no_db():
+    handler = _make_handler(RangedUploadStatusHandler)
+    with patch_db_conn(None):
+        await handler.get("x")
+    handler.set_status.assert_called_with(500)

--- a/tests/test_server_runtime.py
+++ b/tests/test_server_runtime.py
@@ -27,7 +27,7 @@ def test_resolve_worker_count_windows_forces_one():
 
 
 def test_detect_physical_cpu_count_fallback():
-    with patch("aird.server_runtime.os.cpu_count", return_value=8), patch(
-        "aird.server_runtime.detect_threads_per_core", return_value=2.0
-    ):
+    with patch("aird.server_runtime.sys.platform", "darwin"), patch(
+        "aird.server_runtime.os.cpu_count", return_value=8
+    ), patch("aird.server_runtime.detect_threads_per_core", return_value=2.0):
         assert detect_physical_cpu_count() == 4

--- a/tests/test_transfer_ws_handlers.py
+++ b/tests/test_transfer_ws_handlers.py
@@ -99,3 +99,34 @@ async def test_download_streams_file(tmp_path):
     assert "download_start" in types
     assert "binary" in types
     assert "download_end" in types
+
+
+def test_ws_helper_functions():
+    from aird.app_context import AppContext
+    from aird.handlers.transfer_ws_handlers import (
+        _ws_db_conn,
+        _ws_display_username,
+        _ws_get_service,
+        _ws_has_modify_privileges,
+    )
+
+    handler = MagicMock()
+    handler.get_current_user.return_value = None
+    assert _ws_has_modify_privileges(handler) is False
+    assert _ws_display_username(handler) == "Guest"
+
+    handler.get_current_user.return_value = {"username": "token_user", "role": "user"}
+    assert _ws_has_modify_privileges(handler) is False
+
+    handler.get_current_user.return_value = {"username": "alice", "role": "user"}
+    assert _ws_has_modify_privileges(handler) is True
+    assert _ws_display_username(handler) == "alice (User)"
+
+    ctx = AppContext(db_conn=object(), services={"audit_service": object()})
+    handler.settings = {"app_context": ctx}
+    assert _ws_db_conn(handler) is ctx.db_conn
+    assert _ws_get_service(handler, "audit_service") is not None
+
+    handler.settings = {"db_conn": "db", "services": {"x": 1}}
+    assert _ws_db_conn(handler) == "db"
+    assert _ws_get_service(handler, "x") == 1

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1259,3 +1259,40 @@ class TestSanitizeCloudFilenameEdgeCases:
     def test_all_underscores_returns_default(self):
         result = sanitize_cloud_filename("___")
         assert result == "cloud_file"
+
+
+class TestShareVisibilityHelpers:
+    def test_share_visible_to_viewer(self):
+        from aird.utils.util import (
+            augment_with_shared_status,
+            share_relevant_for_viewers_file_tree,
+            share_visible_to_viewer_for_listing,
+        )
+
+        share = {
+            "paths": ["docs"],
+            "allowed_users": ["bob"],
+            "created_by": "alice",
+        }
+        assert share_visible_to_viewer_for_listing(share, "bob", False) is True
+        assert share_visible_to_viewer_for_listing(share, None, False) is False
+        assert share_visible_to_viewer_for_listing(share, "eve", False) is False
+        assert share_visible_to_viewer_for_listing(share, "eve", True) is True
+
+        with patch(
+            "aird.core.share_root.filesystem_root_for_share", return_value="/root"
+        ):
+            assert share_relevant_for_viewers_file_tree(
+                share, viewer_username="bob", viewer_is_admin=False, viewer_root="/root"
+            )
+
+        files = [{"name": "a.txt"}]
+        augment_with_shared_status(
+            files,
+            "",
+            {"s1": share},
+            viewer_username="bob",
+            viewer_is_admin=False,
+        )
+        assert "is_shared" in files[0]
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebased onto **`ft`** (not `main`). Increases `aird` package coverage on the ft branch from **70% → 80%**.

## Changes

- Cherry-picked and adapted coverage tests for ft-specific code (upload config, ranged CLI transfers, seeded ABAC policies, free-threading helpers).
- **New tests:** `test_quick_win_coverage.py`, `test_abac_handlers.py`, `test_cli_session_extended.py`, `test_cli_transfer_http.py`, `test_file_send.py`, `test_ranged_upload_handlers_extended.py`, `test_mmap_extended.py`
- **Extended tests:** util, main, ldap, http_range, folder_size, email, transfer_ws, server_runtime
- Fixed cross-test pollution (upload config restore) and ft-specific assertion updates

## Coverage (ft branch)

```
TOTAL: 70% → 80%  (11,240 statements)
```

## Test plan

- [x] `python3 -m pytest --cov=aird --cov-report=term -q` → **80%** on ft
- [x] **1873 passed**, 3 skipped

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74f1b918-229c-4acc-8e03-7bc759271d25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74f1b918-229c-4acc-8e03-7bc759271d25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

